### PR TITLE
bsc#1197697 - Adaption to new go compiler behavior regarding test and build

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,8 +27,7 @@ Usage:
 	# hana-firewall define-new-hana-service
 		Interactively create a new HANA network service definition.
 	# hana-firewall help
-		Display this help message.
-`)
+		Display this help message.`)
 	os.Exit(exitStatus)
 }
 


### PR DESCRIPTION
fix redundant newline to pass the go tests

and in the spec file (on ibs): 
change go namespace from HouzuoGuo to SUSE
and add GO111MODULE=off to avoid test and build errors